### PR TITLE
Branch name extraction in plugin

### DIFF
--- a/BuildNotifications.Core.Tests/MockBranch.cs
+++ b/BuildNotifications.Core.Tests/MockBranch.cs
@@ -17,5 +17,6 @@ namespace BuildNotifications.Core.Tests
 
         public string DisplayName { get; }
         public string FullName { get; }
+        public bool IsPullRequest => false;
     }
 }

--- a/BuildNotifications.Core.Tests/MockBranch.cs
+++ b/BuildNotifications.Core.Tests/MockBranch.cs
@@ -6,16 +6,16 @@ namespace BuildNotifications.Core.Tests
     {
         public MockBranch(string name)
         {
-            Name = DisplayName = name;
+            FullName = DisplayName = name;
         }
 
         public bool Equals(IBranch other)
         {
             var mock = other as MockBranch;
-            return mock?.Name.Equals(Name) == true;
+            return mock?.FullName.Equals(FullName) == true;
         }
 
         public string DisplayName { get; }
-        public string Name { get; }
+        public string FullName { get; }
     }
 }

--- a/BuildNotifications.Core.Tests/Pipeline/Notification/NotificationFactoryTests.cs
+++ b/BuildNotifications.Core.Tests/Pipeline/Notification/NotificationFactoryTests.cs
@@ -29,25 +29,25 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             _mobileDefinition.Name.Returns(Mobile);
 
             _stageBranch = Substitute.For<IBranch>();
-            _stageBranch.Name.Returns(Stage);
+            _stageBranch.FullName.Returns(Stage);
 
             _masterBranch = Substitute.For<IBranch>();
-            _masterBranch.Name.Returns(Master);
+            _masterBranch.FullName.Returns(Master);
 
             _featureBranch = Substitute.For<IBranch>();
-            _featureBranch.Name.Returns(Feature);
+            _featureBranch.FullName.Returns(Feature);
 
             _bugBranch = Substitute.For<IBranch>();
-            _bugBranch.Name.Returns(Bug);
+            _bugBranch.FullName.Returns(Bug);
 
             _longNameFeatureABranch = Substitute.For<IBranch>();
-            _longNameFeatureABranch.Name.Returns(LongNameFeatureA);
+            _longNameFeatureABranch.FullName.Returns(LongNameFeatureA);
 
             _longNameFeatureBBranch = Substitute.For<IBranch>();
-            _longNameFeatureBBranch.Name.Returns(LongNameFeatureB);
+            _longNameFeatureBBranch.FullName.Returns(LongNameFeatureB);
 
             _longNameFeatureCBranch = Substitute.For<IBranch>();
-            _longNameFeatureCBranch.Name.Returns(LongNameFeatureC);
+            _longNameFeatureCBranch.FullName.Returns(LongNameFeatureC);
 
             _me = Substitute.For<IUser>();
             _me.UniqueName.Returns("Me");
@@ -158,7 +158,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
         {
             var build = Substitute.For<IBuild>();
             build.Definition.Returns(definition);
-            var branchName = branch.Name;
+            var branchName = branch.FullName;
             build.BranchName.Returns(branchName);
             build.Id.Returns(id);
             build.Status.Returns(status);
@@ -191,7 +191,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             // assert
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BranchNotification.BranchChangedTextId);
-            Assert.True(message.DisplayContent.Contains(_masterBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_masterBranch.FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -213,7 +213,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             var message = messages.First();
             Assert.Equal(message.ContentTextId, DefinitionAndBranchNotification.BranchAndDefinitionFailedTextId);
             Assert.True(message.DisplayContent.Contains(_ciDefinition.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -255,9 +255,9 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             // assert
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BranchNotification.ThreeBranchesChangedTextId);
-            Assert.True(message.DisplayContent.Contains(_masterBranch.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_featureBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_masterBranch.FullName, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_featureBranch.FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -305,8 +305,8 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             // assert
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BranchNotification.TwoBranchesChangedTextId);
-            Assert.True(message.DisplayContent.Contains(_masterBranch.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_masterBranch.FullName, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -325,7 +325,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             // assert
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BranchNotification.BranchChangedTextId);
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -610,7 +610,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BuildNotification.BuildChangedTextId);
             Assert.True(message.DisplayContent.Contains(_ciDefinition.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -628,7 +628,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BuildNotification.BuildChangedTextId);
             Assert.True(message.DisplayContent.Contains(_ciDefinition.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
             Assert.Equal(BuildStatus.Succeeded, message.Status);
         }
 
@@ -647,7 +647,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Notification
             var message = messages.First();
             Assert.Equal(message.ContentTextId, BuildNotification.BuildChangedTextId);
             Assert.True(message.DisplayContent.Contains(_ciDefinition.Name, StringComparison.Ordinal));
-            Assert.True(message.DisplayContent.Contains(_stageBranch.Name, StringComparison.Ordinal));
+            Assert.True(message.DisplayContent.Contains(_stageBranch.FullName, StringComparison.Ordinal));
             Assert.Equal(BuildStatus.Failed, message.Status);
         }
     }

--- a/BuildNotifications.Core.Tests/Pipeline/PipelineTests.cs
+++ b/BuildNotifications.Core.Tests/Pipeline/PipelineTests.cs
@@ -7,7 +7,6 @@ using BuildNotifications.Core.Pipeline;
 using BuildNotifications.Core.Pipeline.Tree;
 using BuildNotifications.Core.Pipeline.Tree.Arrangement;
 using BuildNotifications.Core.Tests.Pipeline.Tree;
-using BuildNotifications.Core.Utilities;
 using BuildNotifications.PluginInterfaces.Builds;
 using BuildNotifications.PluginInterfaces.SourceControl;
 using NSubstitute;
@@ -36,7 +35,7 @@ namespace BuildNotifications.Core.Tests.Pipeline
             var sut = new Core.Pipeline.Pipeline(builder, configuration);
 
             var buildProvider = Substitute.For<IBuildProvider>();
-            var project = new Project(buildProvider, Substitute.For<IBranchProvider>(), Substitute.For<IProjectConfiguration>(), Substitute.For<IBranchNameExtractor>());
+            var project = new Project(buildProvider, Substitute.For<IBranchProvider>(), Substitute.For<IProjectConfiguration>());
             sut.AddProject(project);
 
             // Act
@@ -56,7 +55,7 @@ namespace BuildNotifications.Core.Tests.Pipeline
 
             var buildProvider = Substitute.For<IBuildProvider>();
 
-            var project = new Project(buildProvider, Substitute.For<IBranchProvider>(), Substitute.For<IProjectConfiguration>(), Substitute.For<IBranchNameExtractor>());
+            var project = new Project(buildProvider, Substitute.For<IBranchProvider>(), Substitute.For<IProjectConfiguration>());
             sut.AddProject(project);
 
             // Act
@@ -103,7 +102,7 @@ namespace BuildNotifications.Core.Tests.Pipeline
             configuration.BuildsToShow.Returns(int.MaxValue);
             var pipeline = new Core.Pipeline.Pipeline(treeBuilder, configuration);
 
-            var project = new Project(buildProvider, branchProvider, Substitute.For<IProjectConfiguration>(), Substitute.For<IBranchNameExtractor>());
+            var project = new Project(buildProvider, branchProvider, Substitute.For<IProjectConfiguration>());
             pipeline.AddProject(project);
 
             IBuildTree? tree = null;

--- a/BuildNotifications.Core.Tests/Pipeline/Tree/BuildTreeParser.cs
+++ b/BuildNotifications.Core.Tests/Pipeline/Tree/BuildTreeParser.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BuildNotifications.Core.Pipeline.Tree;
+
+namespace BuildNotifications.Core.Tests.Pipeline.Tree
+{
+    internal class BuildTreeParser
+    {
+        public BuildTreeParser(IBuildTreeNode tree)
+        {
+            _tree = tree;
+        }
+
+        public IEnumerable<IBuildTreeNode> ChildrenAtLevel(int level)
+        {
+            if (level == 0)
+                return _tree.Yield();
+
+            var currentLevel = 1;
+
+            var currentChildren = _tree.Children.ToList();
+
+            while (currentLevel < level && currentChildren.Any())
+            {
+                currentChildren = currentChildren.SelectMany(x => x.Children).ToList();
+                ++currentLevel;
+            }
+
+            return currentChildren;
+        }
+
+        private readonly IBuildTreeNode _tree;
+    }
+}

--- a/BuildNotifications.Core.Tests/Pipeline/Tree/TreeBuilderTests.cs
+++ b/BuildNotifications.Core.Tests/Pipeline/Tree/TreeBuilderTests.cs
@@ -61,7 +61,7 @@ namespace BuildNotifications.Core.Tests.Pipeline.Tree
         {
             var build = Substitute.For<IBuild>();
             build.Definition.Returns(definition);
-            build.BranchName.Returns(branch.Name);
+            build.BranchName.Returns(branch.FullName);
             build.Id.Returns(id);
 
             return build;

--- a/BuildNotifications.Core.Tests/Pipeline/Tree/TreeBuilderTests.cs
+++ b/BuildNotifications.Core.Tests/Pipeline/Tree/TreeBuilderTests.cs
@@ -12,34 +12,6 @@ using Xunit;
 
 namespace BuildNotifications.Core.Tests.Pipeline.Tree
 {
-    internal class BuildTreeParser
-    {
-        public BuildTreeParser(IBuildTreeNode tree)
-        {
-            _tree = tree;
-        }
-
-        public IEnumerable<IBuildTreeNode> ChildrenAtLevel(int level)
-        {
-            if (level == 0)
-                return _tree.Yield();
-
-            var currentLevel = 1;
-
-            var currentChildren = _tree.Children.ToList();
-
-            while (currentLevel < level && currentChildren.Any())
-            {
-                currentChildren = currentChildren.SelectMany(x => x.Children).ToList();
-                ++currentLevel;
-            }
-
-            return currentChildren;
-        }
-
-        private readonly IBuildTreeNode _tree;
-    }
-
     public class TreeBuilderTests
     {
         internal static TreeBuilder Construct(params GroupDefinition[] definitions)
@@ -49,12 +21,10 @@ namespace BuildNotifications.Core.Tests.Pipeline.Tree
             var config = Substitute.For<IConfiguration>();
             config.GroupDefinition.Returns(groupDefinition);
 
-            var branchNameExtractor = Substitute.For<IBranchNameExtractor>();
-
             var searcher = Substitute.For<IBuildSearcher>();
             searcher.Matches(Arg.Any<IBuild>(), Arg.Any<string>()).Returns(true);
 
-            return new TreeBuilder(config, branchNameExtractor, searcher);
+            return new TreeBuilder(config, searcher);
         }
 
         private IBuild CreateBuild(IBuildDefinition definition, IBranch branch, string id)

--- a/BuildNotifications.Core.Tests/Utilities/BranchNameExtractorTests.cs
+++ b/BuildNotifications.Core.Tests/Utilities/BranchNameExtractorTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using BuildNotifications.Core.Utilities;
-using BuildNotifications.PluginInterfaces.SourceControl;
+﻿using BuildNotifications.Core.Utilities;
 using Xunit;
 
 namespace BuildNotifications.Core.Tests.Utilities
@@ -18,7 +16,7 @@ namespace BuildNotifications.Core.Tests.Utilities
             var sut = new BranchNameExtractor();
 
             // Act
-            var actual = sut.ExtractDisplayName(input, Enumerable.Empty<IBranch>());
+            var actual = sut.ExtractDisplayName(input);
 
             // Assert
             Assert.Equal(expected, actual);

--- a/BuildNotifications.Core/CoreSetup.cs
+++ b/BuildNotifications.Core/CoreSetup.cs
@@ -26,9 +26,8 @@ namespace BuildNotifications.Core
 
             ProjectProvider = new ProjectProvider(Configuration, PluginRepository);
 
-            var branchNameExtractor = new BranchNameExtractor();
             var searcher = new BuildSearcher();
-            var treeBuilder = new TreeBuilder(Configuration, branchNameExtractor, searcher);
+            var treeBuilder = new TreeBuilder(Configuration, searcher);
             Pipeline = new Pipeline.Pipeline(treeBuilder, Configuration);
 
             Pipeline.Notifier.Updated += Notifier_Updated;

--- a/BuildNotifications.Core/Pipeline/BranchMatcher.cs
+++ b/BuildNotifications.Core/Pipeline/BranchMatcher.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using BuildNotifications.Core.Config;
-using BuildNotifications.Core.Utilities;
 using BuildNotifications.PluginInterfaces.Builds;
+using BuildNotifications.PluginInterfaces.SourceControl;
 
 namespace BuildNotifications.Core.Pipeline
 {

--- a/BuildNotifications.Core/Pipeline/NullBranchNameExtractor.cs
+++ b/BuildNotifications.Core/Pipeline/NullBranchNameExtractor.cs
@@ -1,0 +1,9 @@
+﻿using BuildNotifications.PluginInterfaces.SourceControl;
+
+namespace BuildNotifications.Core.Pipeline
+{
+    internal class NullBranchNameExtractor : IBranchNameExtractor
+    {
+        public string ExtractDisplayName(string fullBranchName) => fullBranchName;
+    }
+}

--- a/BuildNotifications.Core/Pipeline/Pipeline.cs
+++ b/BuildNotifications.Core/Pipeline/Pipeline.cs
@@ -102,7 +102,7 @@ namespace BuildNotifications.Core.Pipeline
                     var count = 0;
                     await foreach (var branch in branches)
                     {
-                        _branchCache.AddOrReplace(projectId, branch.Name.GetHashCode(), branch);
+                        _branchCache.AddOrReplace(projectId, branch.FullName.GetHashCode(), branch);
                         count += 1;
                     }
 
@@ -113,7 +113,7 @@ namespace BuildNotifications.Core.Pipeline
                     count = 0;
                     await foreach (var branch in removedBranches)
                     {
-                        _branchCache.Remove(projectId, branch.Name.GetHashCode());
+                        _branchCache.Remove(projectId, branch.FullName.GetHashCode());
                         count += 1;
                     }
 

--- a/BuildNotifications.Core/Pipeline/Project.cs
+++ b/BuildNotifications.Core/Pipeline/Project.cs
@@ -188,6 +188,7 @@ namespace BuildNotifications.Core.Pipeline
 
             public string DisplayName { get; }
             public string FullName { get; }
+            public bool IsPullRequest => false;
         }
     }
 }

--- a/BuildNotifications.Core/Pipeline/Project.cs
+++ b/BuildNotifications.Core/Pipeline/Project.cs
@@ -182,11 +182,11 @@ namespace BuildNotifications.Core.Pipeline
                 DisplayName = string.Empty;
             }
 
-            public bool Equals(IBranch other) => false;
-
             public string DisplayName { get; }
             public string FullName { get; }
             public bool IsPullRequest => false;
+
+            bool IEquatable<IBranch>.Equals(IBranch other) => false;
         }
     }
 }

--- a/BuildNotifications.Core/Pipeline/Project.cs
+++ b/BuildNotifications.Core/Pipeline/Project.cs
@@ -121,8 +121,8 @@ namespace BuildNotifications.Core.Pipeline
 
             foreach (var build in enrichedBuilds)
             {
-                var branch = branchList.FirstOrDefault(b => b.Name == build.BranchName)
-                             ?? branchList.FirstOrDefault(b => b.Name == build.Branch?.Name)
+                var branch = branchList.FirstOrDefault(b => b.FullName == build.BranchName)
+                             ?? branchList.FirstOrDefault(b => b.FullName == build.Branch?.FullName)
                              ?? new NullBranch();
                 build.Branch = branch;
 
@@ -180,14 +180,14 @@ namespace BuildNotifications.Core.Pipeline
         {
             public NullBranch()
             {
-                Name = string.Empty;
+                FullName = string.Empty;
                 DisplayName = string.Empty;
             }
 
             public bool Equals(IBranch other) => false;
 
             public string DisplayName { get; }
-            public string Name { get; }
+            public string FullName { get; }
         }
     }
 }

--- a/BuildNotifications.Core/Pipeline/Project.cs
+++ b/BuildNotifications.Core/Pipeline/Project.cs
@@ -13,27 +13,24 @@ namespace BuildNotifications.Core.Pipeline
 {
     internal class Project : IProject
     {
-        public Project(IEnumerable<IBuildProvider> buildProviders, IEnumerable<IBranchProvider> branchProviders,
+        public Project(IEnumerable<IBuildProvider> buildProviders, IBranchProvider branchProvider,
             IProjectConfiguration config, IBranchNameExtractor branchNameExtractor)
         {
             _branchNameExtractor = branchNameExtractor;
             Name = config.ProjectName;
             _buildProviders = buildProviders.ToList();
-            _branchProviders = branchProviders.ToList();
+            _branchProvider = branchProvider;
             Config = config;
 
             _buildFilter = new ListBuildFilter(config);
         }
 
         public Project(IBuildProvider buildProvider, IBranchProvider branchProvider, IProjectConfiguration config, IBranchNameExtractor branchNameExtractor)
-            : this(buildProvider.Yield(), branchProvider.Yield(), config, branchNameExtractor)
+            : this(buildProvider.Yield(), branchProvider, config, branchNameExtractor)
         {
         }
 
-        private IBuild Enrich(IBaseBuild build, IBuildProvider buildProvider)
-        {
-            return new EnrichedBuild(build, Name, buildProvider);
-        }
+        private IBuild Enrich(IBaseBuild build, IBuildProvider buildProvider) => new EnrichedBuild(build, Name, buildProvider);
 
         private string ExtractBranchName(IPullRequest pr)
         {
@@ -51,10 +48,7 @@ namespace BuildNotifications.Core.Pipeline
             }
         }
 
-        private bool IsAllowed(IBaseBuild build)
-        {
-            return _buildFilter.IsAllowed(build);
-        }
+        private bool IsAllowed(IBaseBuild build) => _buildFilter.IsAllowed(build);
 
         public IProjectConfiguration Config { get; set; }
 
@@ -94,24 +88,18 @@ namespace BuildNotifications.Core.Pipeline
 
         public async IAsyncEnumerable<IBranch> FetchExistingBranches()
         {
-            foreach (var branchProvider in _branchProviders)
+            await foreach (var branch in _branchProvider.FetchExistingBranches())
             {
-                await foreach (var branch in branchProvider.FetchExistingBranches())
-                {
-                    if (Config.PullRequestDisplay != PullRequestDisplayMode.None || !(branch is IPullRequest))
-                        yield return branch;
-                }
+                if (Config.PullRequestDisplay != PullRequestDisplayMode.None || !(branch is IPullRequest))
+                    yield return branch;
             }
         }
 
         public async IAsyncEnumerable<IBranch> FetchRemovedBranches()
         {
-            foreach (var branchProvider in _branchProviders)
+            await foreach (var branch in _branchProvider.RemovedBranches())
             {
-                await foreach (var branch in branchProvider.RemovedBranches())
-                {
-                    yield return branch;
-                }
+                yield return branch;
             }
         }
 
@@ -133,8 +121,8 @@ namespace BuildNotifications.Core.Pipeline
 
             foreach (var build in enrichedBuilds)
             {
-                var branch = branchList.FirstOrDefault(b => b.Name == build.BranchName) 
-                             ?? branchList.FirstOrDefault(b => b.Name == build.Branch?.Name) 
+                var branch = branchList.FirstOrDefault(b => b.Name == build.BranchName)
+                             ?? branchList.FirstOrDefault(b => b.Name == build.Branch?.Name)
                              ?? new NullBranch();
                 build.Branch = branch;
 
@@ -184,7 +172,7 @@ namespace BuildNotifications.Core.Pipeline
         }
 
         private readonly IBranchNameExtractor _branchNameExtractor;
-        private readonly List<IBranchProvider> _branchProviders;
+        private readonly IBranchProvider _branchProvider;
         private readonly List<IBuildProvider> _buildProviders;
         private readonly ListBuildFilter _buildFilter;
 
@@ -196,10 +184,7 @@ namespace BuildNotifications.Core.Pipeline
                 DisplayName = string.Empty;
             }
 
-            public bool Equals(IBranch other)
-            {
-                return false;
-            }
+            public bool Equals(IBranch other) => false;
 
             public string DisplayName { get; }
             public string Name { get; }

--- a/BuildNotifications.Core/Pipeline/ProjectFactory.cs
+++ b/BuildNotifications.Core/Pipeline/ProjectFactory.cs
@@ -88,6 +88,11 @@ namespace BuildNotifications.Core.Pipeline
             return _configuration.Connections.FirstOrDefault(c => c.Name == connectionName);
         }
 
+        private static string JoinStringList(IEnumerable<string> strings)
+        {
+            return string.Join(",", strings.Select(s => $"'{s}'"));
+        }
+
         private void ReportError(string messageTextId, params object[] parameter)
         {
             var localizedMessage = StringLocalizer.Instance.GetText(messageTextId);
@@ -102,7 +107,9 @@ namespace BuildNotifications.Core.Pipeline
 
         public IProject? Construct(IProjectConfiguration config)
         {
-            LogTo.Debug($"Trying to construct project from {config.BuildConnectionNames} and {config.SourceControlConnectionNames}");
+            LogTo.Debug($"Trying to construct project from {JoinStringList(config.BuildConnectionNames)} and {JoinStringList(config.SourceControlConnectionNames)}");
+            if (config.SourceControlConnectionNames.Count > 1)
+                LogTo.Warn("Multiple SourceControlConnections per project are no longer supported. Using first one in list.");
 
             var buildProviders = new List<IBuildProvider>();
             foreach (var connectionName in config.BuildConnectionNames)
@@ -118,7 +125,7 @@ namespace BuildNotifications.Core.Pipeline
             }
 
             var branchProviders = new List<IBranchProvider>();
-            foreach (var connectionName in config.SourceControlConnectionNames)
+            foreach (var connectionName in config.SourceControlConnectionNames.Take(1))
             {
                 var branchProvider = BranchProvider(connectionName);
                 if (branchProvider == null)
@@ -131,7 +138,7 @@ namespace BuildNotifications.Core.Pipeline
             }
 
             var branchNameExtractor = new BranchNameExtractor();
-            return new Project(buildProviders, branchProviders, config, branchNameExtractor);
+            return new Project(buildProviders, branchProviders.FirstOrDefault(), config, branchNameExtractor);
         }
 
         public event EventHandler<ErrorNotificationEventArgs>? ErrorOccured;

--- a/BuildNotifications.Core/Pipeline/ProjectFactory.cs
+++ b/BuildNotifications.Core/Pipeline/ProjectFactory.cs
@@ -5,7 +5,6 @@ using Anotar.NLog;
 using BuildNotifications.Core.Config;
 using BuildNotifications.Core.Plugin;
 using BuildNotifications.Core.Text;
-using BuildNotifications.Core.Utilities;
 using BuildNotifications.PluginInterfaces.Builds;
 using BuildNotifications.PluginInterfaces.SourceControl;
 
@@ -137,8 +136,7 @@ namespace BuildNotifications.Core.Pipeline
                 branchProviders.Add(branchProvider);
             }
 
-            var branchNameExtractor = new BranchNameExtractor();
-            return new Project(buildProviders, branchProviders.FirstOrDefault(), config, branchNameExtractor);
+            return new Project(buildProviders, branchProviders.FirstOrDefault(), config);
         }
 
         public event EventHandler<ErrorNotificationEventArgs>? ErrorOccured;

--- a/BuildNotifications.Core/Pipeline/Tree/TreeBuilder.cs
+++ b/BuildNotifications.Core/Pipeline/Tree/TreeBuilder.cs
@@ -10,11 +10,9 @@ namespace BuildNotifications.Core.Pipeline.Tree
 {
     internal class TreeBuilder : ITreeBuilder
     {
-        public TreeBuilder(IConfiguration config, IBranchNameExtractor branchNameExtractor,
-            IBuildSearcher searcher)
+        public TreeBuilder(IConfiguration config, IBuildSearcher searcher)
         {
             _config = config;
-            _branchNameExtractor = branchNameExtractor;
             _searcher = searcher;
         }
 
@@ -46,7 +44,7 @@ namespace BuildNotifications.Core.Pipeline.Tree
                 {
                     var enrichedBuild = build as EnrichedBuild;
                     var isPullRequest = enrichedBuild?.Branch?.IsPullRequest ?? false;
-                    var displayName = _branchNameExtractor.ExtractDisplayName(build.BranchName);
+                    var displayName = enrichedBuild?.Branch?.DisplayName ?? build.BranchName;
                     return new BranchGroupNode(displayName, isPullRequest);
                 }
                 case Arrangement.GroupDefinition.BuildDefinition:
@@ -127,7 +125,6 @@ namespace BuildNotifications.Core.Pipeline.Tree
         }
 
         private readonly IConfiguration _config;
-        private readonly IBranchNameExtractor _branchNameExtractor;
         private readonly IBuildSearcher _searcher;
     }
 }

--- a/BuildNotifications.Core/Pipeline/Tree/TreeBuilder.cs
+++ b/BuildNotifications.Core/Pipeline/Tree/TreeBuilder.cs
@@ -45,7 +45,7 @@ namespace BuildNotifications.Core.Pipeline.Tree
                 case Arrangement.GroupDefinition.Branch:
                 {
                     var enrichedBuild = build as EnrichedBuild;
-                    var isPullRequest = _branchNameExtractor.IsPullRequest(enrichedBuild?.Branch?.Name);
+                    var isPullRequest = _branchNameExtractor.IsPullRequest(enrichedBuild?.Branch?.FullName);
                     var displayName = _branchNameExtractor.ExtractDisplayName(build.BranchName);
                     return new BranchGroupNode(displayName, isPullRequest);
                 }

--- a/BuildNotifications.Core/Pipeline/Tree/TreeBuilder.cs
+++ b/BuildNotifications.Core/Pipeline/Tree/TreeBuilder.cs
@@ -45,7 +45,7 @@ namespace BuildNotifications.Core.Pipeline.Tree
                 case Arrangement.GroupDefinition.Branch:
                 {
                     var enrichedBuild = build as EnrichedBuild;
-                    var isPullRequest = _branchNameExtractor.IsPullRequest(enrichedBuild?.Branch?.FullName);
+                    var isPullRequest = enrichedBuild?.Branch?.IsPullRequest ?? false;
                     var displayName = _branchNameExtractor.ExtractDisplayName(build.BranchName);
                     return new BranchGroupNode(displayName, isPullRequest);
                 }

--- a/BuildNotifications.Core/Utilities/BranchNameExtractor.cs
+++ b/BuildNotifications.Core/Utilities/BranchNameExtractor.cs
@@ -16,12 +16,6 @@ namespace BuildNotifications.Core.Utilities
             return fullBranchName;
         }
 
-        public bool IsPullRequest(string? fullBranchName)
-        {
-            var match = PullRequestPattern.Match(fullBranchName);
-            return match.Success;
-        }
-
         private const string GitRefHeadPrefix = "refs/heads/";
         private static readonly Regex PullRequestPattern = new Regex("refs\\/pull\\/([\\d]+)\\/merge", RegexOptions.Compiled);
     }

--- a/BuildNotifications.Core/Utilities/BranchNameExtractor.cs
+++ b/BuildNotifications.Core/Utilities/BranchNameExtractor.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
-using BuildNotifications.PluginInterfaces.SourceControl;
+﻿using System.Text.RegularExpressions;
 
 namespace BuildNotifications.Core.Utilities
 {
@@ -23,14 +20,6 @@ namespace BuildNotifications.Core.Utilities
         {
             var match = PullRequestPattern.Match(fullBranchName);
             return match.Success;
-        }
-
-        public string ExtractDisplayName(string fullBranchName, IEnumerable<IBranch> allBranches)
-        {
-            var matchingBranch = allBranches.FirstOrDefault(b => b.Name == fullBranchName);
-#pragma warning disable 618
-            return matchingBranch?.DisplayName ?? ExtractDisplayName(fullBranchName);
-#pragma warning restore 618
         }
 
         private const string GitRefHeadPrefix = "refs/heads/";

--- a/BuildNotifications.Core/Utilities/IBranchNameExtractor.cs
+++ b/BuildNotifications.Core/Utilities/IBranchNameExtractor.cs
@@ -2,8 +2,6 @@
 {
     public interface IBranchNameExtractor
     {
-        bool IsPullRequest(string? fullBranchName);
-
         /// <summary>
         /// Extract name from branch that can be used for display in the UI.
         /// </summary>

--- a/BuildNotifications.Core/Utilities/IBranchNameExtractor.cs
+++ b/BuildNotifications.Core/Utilities/IBranchNameExtractor.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using BuildNotifications.PluginInterfaces.SourceControl;
-
-namespace BuildNotifications.Core.Utilities
+﻿namespace BuildNotifications.Core.Utilities
 {
     public interface IBranchNameExtractor
     {
@@ -11,10 +8,7 @@ namespace BuildNotifications.Core.Utilities
         /// Extract name from branch that can be used for display in the UI.
         /// </summary>
         /// <param name="fullBranchName">Full name of the branch.</param>
-        /// <param name="allBranches">List of all existing branches.</param>
         /// <returns>A name that can be used to display the branch in the UI.</returns>
-        string ExtractDisplayName(string fullBranchName, IEnumerable<IBranch> allBranches);
-
         string ExtractDisplayName(string fullBranchName);
     }
 }

--- a/BuildNotifications.Tests/BuildNotifications.Tests.csproj
+++ b/BuildNotifications.Tests/BuildNotifications.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BuildNotifications\BuildNotifications.csproj" />
+    <ProjectReference Include="..\Plugins\BuildNotifications.Plugin.Tfs\BuildNotifications.Plugin.Tfs.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BuildNotifications.Tests/Plugins/Tfs/GitBranchNameExtractorTests.cs
+++ b/BuildNotifications.Tests/Plugins/Tfs/GitBranchNameExtractorTests.cs
@@ -1,9 +1,9 @@
-﻿using BuildNotifications.Core.Utilities;
+﻿using BuildNotifications.Plugin.Tfs;
 using Xunit;
 
-namespace BuildNotifications.Core.Tests.Utilities
+namespace BuildNotifications.Tests.Plugins.Tfs
 {
-    public class BranchNameExtractorTests
+    public class GitBranchNameExtractorTests
     {
         [Theory]
         [InlineData("refs/heads/master", "master")]
@@ -13,7 +13,7 @@ namespace BuildNotifications.Core.Tests.Utilities
         public void ExtractDisplayNameShouldRemoveGitPrefixes(string input, string expected)
         {
             // Arrange
-            var sut = new BranchNameExtractor();
+            var sut = new GitBranchNameExtractor();
 
             // Act
             var actual = sut.ExtractDisplayName(input);

--- a/DummyBuildServer/ViewModels/BranchViewModel.cs
+++ b/DummyBuildServer/ViewModels/BranchViewModel.cs
@@ -7,7 +7,7 @@ namespace DummyBuildServer.ViewModels
         public BranchViewModel(Branch branch)
         {
             Branch = branch;
-            Name = branch.Name;
+            Name = branch.FullName;
         }
 
         public Branch Branch { get; }

--- a/DummyBuildServer/ViewModels/BuildListViewModel.cs
+++ b/DummyBuildServer/ViewModels/BuildListViewModel.cs
@@ -115,7 +115,7 @@ namespace DummyBuildServer.ViewModels
                 LastChangedTime = DateTime.Now,
                 QueueTime = DateTime.Now,
                 Definition = definition,
-                BranchName = branch.Name,
+                BranchName = branch.FullName,
                 RequestedBy = RandomUser(),
                 RequestedFor = user,
                 Status = BuildStatus.Pending,

--- a/Plugins/BuildNotifications.Plugin.DummyBuildServer/Branch.cs
+++ b/Plugins/BuildNotifications.Plugin.DummyBuildServer/Branch.cs
@@ -10,7 +10,7 @@ namespace BuildNotifications.Plugin.DummyBuildServer
 
         public Branch(string name)
         {
-            DisplayName = Name = name;
+            DisplayName = FullName = name;
         }
 
         public override string ToString()
@@ -20,11 +20,11 @@ namespace BuildNotifications.Plugin.DummyBuildServer
 
         public bool Equals(IBranch other)
         {
-            return Name == (other as Branch)?.Name;
+            return FullName == (other as Branch)?.FullName;
         }
 
         public string DisplayName { get; set; }
 
-        public string Name { get; set; }
+        public string FullName { get; set; }
     }
 }

--- a/Plugins/BuildNotifications.Plugin.DummyBuildServer/Branch.cs
+++ b/Plugins/BuildNotifications.Plugin.DummyBuildServer/Branch.cs
@@ -13,18 +13,13 @@ namespace BuildNotifications.Plugin.DummyBuildServer
             DisplayName = FullName = name;
         }
 
-        public override string ToString()
-        {
-            return DisplayName;
-        }
+        public override string ToString() => DisplayName;
 
-        public bool Equals(IBranch other)
-        {
-            return FullName == (other as Branch)?.FullName;
-        }
+        public bool Equals(IBranch other) => FullName == (other as Branch)?.FullName;
 
         public string DisplayName { get; set; }
 
         public string FullName { get; set; }
+        public bool IsPullRequest => false;
     }
 }

--- a/Plugins/BuildNotifications.Plugin.DummyBuildServer/BranchComparer.cs
+++ b/Plugins/BuildNotifications.Plugin.DummyBuildServer/BranchComparer.cs
@@ -6,12 +6,12 @@ namespace BuildNotifications.Plugin.DummyBuildServer
     {
         public bool Equals(Branch x, Branch y)
         {
-            return x?.Name.Equals(y?.Name) == true;
+            return x?.FullName.Equals(y?.FullName) == true;
         }
 
         public int GetHashCode(Branch obj)
         {
-            return obj.Name.GetHashCode();
+            return obj.FullName.GetHashCode();
         }
     }
 }

--- a/Plugins/BuildNotifications.Plugin.DummyBuildServer/BranchNameExtractor.cs
+++ b/Plugins/BuildNotifications.Plugin.DummyBuildServer/BranchNameExtractor.cs
@@ -1,0 +1,9 @@
+﻿using BuildNotifications.PluginInterfaces.SourceControl;
+
+namespace BuildNotifications.Plugin.DummyBuildServer
+{
+    internal class BranchNameExtractor : IBranchNameExtractor
+    {
+        public string ExtractDisplayName(string fullBranchName) => fullBranchName;
+    }
+}

--- a/Plugins/BuildNotifications.Plugin.DummyBuildServer/SourceControlProvider.cs
+++ b/Plugins/BuildNotifications.Plugin.DummyBuildServer/SourceControlProvider.cs
@@ -12,6 +12,8 @@ namespace BuildNotifications.Plugin.DummyBuildServer
             _connection = connection;
         }
 
+        public IBranchNameExtractor NameExtractor => new BranchNameExtractor();
+
         public async IAsyncEnumerable<IBranch> FetchExistingBranches()
         {
             var json = await _connection.Query(Constants.Queries.Branches);

--- a/Plugins/BuildNotifications.Plugin.Tfs/AssemblyInfo.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/AssemblyInfo.cs
@@ -1,3 +1,5 @@
-﻿using Anotar.NLog;
+﻿using System.Runtime.CompilerServices;
+using Anotar.NLog;
 
 [assembly: LogMinimalMessage]
+[assembly: InternalsVisibleTo("BuildNotifications.Tests")]

--- a/Plugins/BuildNotifications.Plugin.Tfs/GitBranchNameExtractor.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/GitBranchNameExtractor.cs
@@ -1,9 +1,9 @@
 ﻿using System.Text.RegularExpressions;
 using BuildNotifications.PluginInterfaces.SourceControl;
 
-namespace BuildNotifications.Core.Utilities
+namespace BuildNotifications.Plugin.Tfs
 {
-    internal class BranchNameExtractor : IBranchNameExtractor
+    internal class GitBranchNameExtractor : IBranchNameExtractor
     {
         public string ExtractDisplayName(string fullBranchName)
         {

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsBranch.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsBranch.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using BuildNotifications.PluginInterfaces.SourceControl;
+﻿using BuildNotifications.PluginInterfaces.SourceControl;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 
 namespace BuildNotifications.Plugin.Tfs
@@ -41,6 +40,5 @@ namespace BuildNotifications.Plugin.Tfs
         private const string BranchNamePrefix = "refs/heads/";
         private const string PullRequestPrefix = "refs/pull/";
         private const string PullRequestSuffix = "/merge";
-        private static readonly Regex PullRequestPattern = new Regex("refs\\/pull\\/([\\d]+)\\/merge", RegexOptions.Compiled);
     }
 }

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsBranch.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsBranch.cs
@@ -1,4 +1,5 @@
-﻿using BuildNotifications.PluginInterfaces.SourceControl;
+﻿using System.Text.RegularExpressions;
+using BuildNotifications.PluginInterfaces.SourceControl;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 
 namespace BuildNotifications.Plugin.Tfs
@@ -25,28 +26,21 @@ namespace BuildNotifications.Plugin.Tfs
 
         public string WebUrl { get; }
 
-        internal static string ComputePullRequestBranchName(int pullRequestId)
-        {
-            return PullRequestPrefix + pullRequestId + PullRequestSuffix;
-        }
+        internal static string ComputePullRequestBranchName(int pullRequestId) => PullRequestPrefix + pullRequestId + PullRequestSuffix;
 
-        private string ExtractDisplayName(string branchName)
-        {
-            return branchName.Replace(BranchNamePrefix, "");
-        }
+        private string ExtractDisplayName(string branchName) => branchName.Replace(BranchNamePrefix, "");
 
-        public bool Equals(IBranch other)
-        {
-            return _id == (other as TfsBranch)?._id;
-        }
+        public bool Equals(IBranch other) => _id == (other as TfsBranch)?._id;
 
         public string DisplayName { get; }
 
         public string FullName { get; }
+        public virtual bool IsPullRequest => false;
 
         private readonly string _id;
         private const string BranchNamePrefix = "refs/heads/";
         private const string PullRequestPrefix = "refs/pull/";
         private const string PullRequestSuffix = "/merge";
+        private static readonly Regex PullRequestPattern = new Regex("refs\\/pull\\/([\\d]+)\\/merge", RegexOptions.Compiled);
     }
 }

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsBranch.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsBranch.cs
@@ -8,7 +8,7 @@ namespace BuildNotifications.Plugin.Tfs
         public TfsBranch(GitRef branch, TfsUrlBuilder urlBuilder)
         {
             DisplayName = ExtractDisplayName(branch.Name);
-            Name = branch.Name;
+            FullName = branch.Name;
             _id = branch.ObjectId;
 
             WebUrl = urlBuilder.BuildBranchUrl(DisplayName);
@@ -17,7 +17,7 @@ namespace BuildNotifications.Plugin.Tfs
         protected TfsBranch(int pullRequestId, TfsUrlBuilder urlBuilder)
         {
             DisplayName = $"PR {pullRequestId}";
-            Name = ComputePullRequestBranchName(pullRequestId);
+            FullName = ComputePullRequestBranchName(pullRequestId);
             _id = pullRequestId.ToString();
 
             WebUrl = urlBuilder.BuildPullRequestUrl(pullRequestId);
@@ -42,7 +42,7 @@ namespace BuildNotifications.Plugin.Tfs
 
         public string DisplayName { get; }
 
-        public string Name { get; }
+        public string FullName { get; }
 
         private readonly string _id;
         private const string BranchNamePrefix = "refs/heads/";

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsBranchComparer.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsBranchComparer.cs
@@ -6,12 +6,12 @@ namespace BuildNotifications.Plugin.Tfs
     {
         public bool Equals(TfsBranch x, TfsBranch y)
         {
-            return x?.Name.Equals(y?.Name) == true;
+            return x?.FullName.Equals(y?.FullName) == true;
         }
 
         public int GetHashCode(TfsBranch obj)
         {
-            return obj.Name.GetHashCode();
+            return obj.FullName.GetHashCode();
         }
     }
 }

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsPullRequests.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsPullRequests.cs
@@ -14,6 +14,7 @@ namespace BuildNotifications.Plugin.Tfs
             Id = native.PullRequestId.ToString();
         }
 
+        public override bool IsPullRequest => true;
         public string Description { get; }
         public string Id { get; }
         public string SourceBranch { get; }

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsSourceControlProvider.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsSourceControlProvider.cs
@@ -18,15 +18,9 @@ namespace BuildNotifications.Plugin.Tfs
             _repositoryId = repositoryId;
         }
 
-        private TfsBranch Convert(GitRef branch, TfsUrlBuilder urlBuilder)
-        {
-            return new TfsBranch(branch, urlBuilder);
-        }
+        private TfsBranch Convert(GitRef branch, TfsUrlBuilder urlBuilder) => new TfsBranch(branch, urlBuilder);
 
-        private TfsPullRequests Convert(GitPullRequest branch, TfsUrlBuilder urlBuilder)
-        {
-            return new TfsPullRequests(branch, urlBuilder);
-        }
+        private TfsPullRequests Convert(GitPullRequest branch, TfsUrlBuilder urlBuilder) => new TfsPullRequests(branch, urlBuilder);
 
         private async Task<List<GitPullRequest>> FetchPullRequests(GitHttpClient gitClient)
         {
@@ -46,6 +40,8 @@ namespace BuildNotifications.Plugin.Tfs
 
             return new TfsUrlBuilder(projectClient.BaseAddress, project.Name);
         }
+
+        public IBranchNameExtractor NameExtractor { get; } = new GitBranchNameExtractor();
 
         public async IAsyncEnumerable<IBranch> FetchExistingBranches()
         {

--- a/Plugins/BuildNotifications.Plugin.Tfs/TfsSourceControlProvider.cs
+++ b/Plugins/BuildNotifications.Plugin.Tfs/TfsSourceControlProvider.cs
@@ -78,7 +78,7 @@ namespace BuildNotifications.Plugin.Tfs
             var pullRequests = await FetchPullRequests(gitClient);
 
             var names = branches.Select(b => b.Name).Concat(pullRequests.Select(p => TfsBranch.ComputePullRequestBranchName(p.PullRequestId)));
-            var deletedBranches = _knownBranches.Where(known => names.All(n => known.Name != n));
+            var deletedBranches = _knownBranches.Where(known => names.All(n => known.FullName != n));
 
             foreach (var branch in deletedBranches)
             {

--- a/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranch.cs
+++ b/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranch.cs
@@ -18,6 +18,6 @@ namespace BuildNotifications.PluginInterfaces.SourceControl
         /// <summary>
         /// The name of the branch.
         /// </summary>
-        string Name { get; }
+        string FullName { get; }
     }
 }

--- a/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranch.cs
+++ b/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranch.cs
@@ -18,5 +18,11 @@ namespace BuildNotifications.PluginInterfaces.SourceControl
         /// The name of the branch.
         /// </summary>
         string FullName { get; }
+
+        /// <summary>
+        /// Indicates whether this branch is a real branch (false) or one that was
+        /// created during/for a pull request (true);
+        /// </summary>
+        bool IsPullRequest { get; }
     }
 }

--- a/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranch.cs
+++ b/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranch.cs
@@ -12,7 +12,6 @@ namespace BuildNotifications.PluginInterfaces.SourceControl
         /// <summary>
         /// Name that can be used when displaying this branch.
         /// </summary>
-        [Obsolete("Will be removed as part of #69")]
         string DisplayName { get; }
 
         /// <summary>

--- a/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranchNameExtractor.cs
+++ b/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranchNameExtractor.cs
@@ -1,5 +1,8 @@
-﻿namespace BuildNotifications.Core.Utilities
+﻿namespace BuildNotifications.PluginInterfaces.SourceControl
 {
+    /// <summary>
+    /// Extracts parts of branch names from full names.
+    /// </summary>
     public interface IBranchNameExtractor
     {
         /// <summary>

--- a/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranchProvider.cs
+++ b/Plugins/BuildNotifications.PluginInterfaces/SourceControl/IBranchProvider.cs
@@ -10,6 +10,11 @@ namespace BuildNotifications.PluginInterfaces.SourceControl
     public interface IBranchProvider
     {
         /// <summary>
+        /// Extractor that can be used on branches from this provider.
+        /// </summary>
+        IBranchNameExtractor NameExtractor { get; }
+
+        /// <summary>
         /// Fetches all branches and PullRequests that are available.
         /// </summary>
         /// <returns>List of all available branches and PullRequests</returns>


### PR DESCRIPTION
Open for discussion since this removes the ability to have multiple source control connections in one project.

If we don't want this we need a way to distinguish branches in one project with the same name. (Image two master branches for example).

If we want this #84 should be done on this branch before completing this PR. Additionally we could/should think about altering the configuration classes and files to replace the list of BranchProviders with a single one.  